### PR TITLE
Add preview feature in yaml and json code editor tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,45 @@
 
 ## Validation structure
 
-The Object and Array type components are wrapped inside `ValidationProvider` and a `ValidationObserver`. The 
+The Object and Array type components are wrapped inside `ValidationProvider` and a `ValidationObserver`. The
+
 - `ValidationProvider` ensures that the Object/Array itself is not empty if required. And also other validations if necessary.
 - `ValidationObserver` ensures to report all the errors occuring in it's nested child components.
 
+## Props
+
+- `reference-model` - A deep copy of the model object that we are modifying using vue-openapi-form component
 
 ## Project setup
+
 ```
 npm install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 npm run serve
 ```
 
 ### Compiles and minifies for production
+
 ```
 npm run build
 ```
 
 ### Run your tests
+
 ```
 npm run test
 ```
 
 ### Lints and fixes files
+
 ```
 npm run lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,6 +51,7 @@
               <vue-openapi-form
                 :schema="jsonSchema"
                 v-model="model"
+                :reference-model="referenceModel || ''"
                 :formTitle="formTitle"
                 :key="JSON.stringify(selectedJsonSchema)"
                 :onValid="onValid"
@@ -81,6 +82,7 @@ export default {
       selectedJsonSchema: Schemas[0],
       jsonSchema: {},
       model: {},
+      referenceModel: {},
       formTitle: "",
       modifiedSchema: false,
     };
@@ -88,8 +90,8 @@ export default {
 
   methods: {
     onValid() {
-      console.log("Form is Valid");
-      console.log(this.model);
+      // console.log("Form is Valid");
+      // console.log(this.model);
     },
     updateSchema(e) {
       this.modifiedSchema = true;
@@ -109,6 +111,7 @@ export default {
         this.jsonSchema = JSON.parse(JSON.stringify(newVal.schema));
         await setTimeout(() => {
           this.model = JSON.parse(JSON.stringify(newVal.model));
+          this.referenceModel = JSON.parse(JSON.stringify(this.model));
         }, 2000);
         this.formTitle = newVal.title;
       },

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,7 +88,8 @@ export default {
 
   methods: {
     onValid() {
-      // console.log("Form is Valid");
+      console.log("Form is Valid");
+      console.log(this.model);
     },
     updateSchema(e) {
       this.modifiedSchema = true;

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -13,3 +13,4 @@
 
 // COMPONENTS
 @import "./../../../node_modules/@appscode/design-system/components/ac-code-highlight";
+@import "./../../../node_modules/@appscode/design-system/components/ac-tabs";

--- a/src/components/ArrayInput.vue
+++ b/src/components/ArrayInput.vue
@@ -36,6 +36,7 @@
           :schema="schema"
           :index="index"
           :value="modelData"
+          :reference-model="referenceModel || []"
         />
         <!-- for each item add control buttons -->
         <div class="form-right-item">
@@ -111,6 +112,7 @@
                   :type="items.type"
                   :errors="errors"
                   v-model="newData"
+                  :reference-model="{}"
                 />
               </validation-provider>
             </template>
@@ -131,6 +133,7 @@
                   :errors="errors"
                   :type="items.type"
                   v-model="newData"
+                  :reference-model="{}"
                 />
               </validation-provider>
             </template>
@@ -151,6 +154,7 @@
                   :errors="errors"
                   :type="items.type"
                   v-model="newData"
+                  :reference-model="[]"
                 />
               </validation-provider>
             </template>
@@ -171,6 +175,7 @@
                   :type="items.type"
                   :validationOb="validationOb"
                   v-model="newData"
+                  :reference-model="''"
                 />
               </validation-provider>
             </template>
@@ -190,7 +195,7 @@
     </template>
     <template v-else-if="activeTab === 'yaml'">
       <!-- declared in tabs component -->
-      <yaml-form v-model="modelData" />
+      <yaml-form v-model="modelData" :reference-model="referenceModel || []" />
 
       <!-- required for validation obserber and validation provider to show proper validation in yaml tab -->
       <div
@@ -205,12 +210,13 @@
           :schema="schema"
           :index="index"
           :value="modelData"
+          :reference-model="{}"
         />
       </div>
     </template>
     <template v-else>
       <!-- declared in tabs component -->
-      <json-form v-model="modelData" />
+      <json-form v-model="modelData" :reference-model="referenceModel || []" />
 
       <!-- required for validation obserber and validation provider to show proper validation in json tab -->
       <div
@@ -225,6 +231,7 @@
           :schema="schema"
           :index="index"
           :value="modelData"
+          :reference-model="{}"
         />
       </div>
     </template>

--- a/src/components/JsonForm.vue
+++ b/src/components/JsonForm.vue
@@ -1,24 +1,56 @@
 <template>
   <div>
-    <monaco-editor
-      ref="monacoEditor"
-      @editorDidMount="onEditorMount"
-      v-model="valueString"
-      :options="editorOptions"
-      language="json"
-      class="editor-writable vh-80 is-clipped"
-    />
+    <!-- tabs start  -->
+    <div class="tabs ac-tabs is-boxed mt-10 mb-2">
+      <ul>
+        <li :class="{ 'is-active': activeTab === 'file' }">
+          <a @click.prevent="activeTab = 'file'">
+            <span>File</span>
+          </a>
+        </li>
+        <li :class="{ 'is-active': activeTab === 'preview-changes' }">
+          <a @click.prevent="activeTab = 'preview-changes'">
+            <span>Preview Changes</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div v-if="activeTab === 'file'">
+      <monaco-editor
+        ref="monacoEditor"
+        @editorDidMount="onEditorMount"
+        v-model="valueString"
+        :options="editorOptions"
+        :diff-editor="activeTab === 'preview-changes'"
+        language="yaml"
+        class="editor-writable vh-80 is-clipped"
+      />
+    </div>
+
+    <div v-else>
+      <monaco-editor
+        :key="activeTab"
+        ref="monacoDiffEditor"
+        class="editor-writable vh-80 is-clipped"
+        :options="editorOptions"
+        :value="valueString"
+        :diff-editor="true"
+        :original="originalValueString"
+        language="yaml"
+      />
+    </div>
   </div>
 </template>
 
 <script>
 import { model } from "../mixins/model.js";
+import jsyaml from "js-yaml";
 import MonacoEditor from "vue-monaco";
 import monacoEditorThemes from "@/plugins/monaco-editor-themes.js";
 import { mapGetters } from "vuex";
 
 export default {
-  name: "json-form",
+  name: "yaml-form",
   props: {
     value: {
       type: null,
@@ -34,6 +66,8 @@ export default {
 
   data() {
     return {
+      activeTab: "file",
+
       valueString: "",
 
       editorOptions: {
@@ -42,6 +76,12 @@ export default {
         },
         readOnly: false,
       },
+      diffEditorOptions: {
+        minimap: {
+          enabled: true,
+        },
+        readOnly: true,
+      },
     };
   },
 
@@ -49,6 +89,9 @@ export default {
     ...mapGetters({
       editorTheme: "editorTheme",
     }),
+    originalValueString() {
+      return JSON.stringify(this.referenceModel, null, 2);
+    },
   },
 
   methods: {
@@ -59,8 +102,10 @@ export default {
     updateModelData() {
       let ans = null;
       try {
-        ans = JSON.parse(this.valueString);
-      } catch {
+        ans = jsyaml.safeLoad(this.valueString, {
+          json: true,
+        }); // yaml => jsObject
+      } catch (e) {
         ans = this.modelData;
       }
 
@@ -77,6 +122,14 @@ export default {
       // set theme
       monacoEditorThemes.setTheme(
         this.$refs.monacoEditor.monaco.editor,
+        this.editorTheme
+      );
+    },
+
+    onDiffEditorMount() {
+      // set theme
+      monacoEditorThemes.setTheme(
+        this.$refs.monacoDiffEditor.monaco.editor,
         this.editorTheme
       );
     },

--- a/src/components/KeyValuePairs.vue
+++ b/src/components/KeyValuePairs.vue
@@ -34,6 +34,7 @@
         >
           <key-value-pair-items
             v-model="keyValueArray[index]"
+            :reference-model="referencekeyValueArray[index] || {}"
             :index="index"
             :schema="schema"
             :additionalProperties="additionalProperties"
@@ -78,6 +79,7 @@
                 :type="`string`"
                 :validationOb="validationOb"
                 v-model="newKey"
+                :reference-model="''"
               />
             </validation-provider>
           </div>
@@ -101,6 +103,7 @@
                   :type="additionalProperties.type"
                   :errors="errors"
                   v-model="newValue"
+                  :reference-model="{}"
                 />
               </validation-provider>
             </template>
@@ -121,6 +124,7 @@
                   :type="additionalProperties.type"
                   :errors="errors"
                   v-model="newValue"
+                  :reference-model="{}"
                 />
               </validation-provider>
             </template>
@@ -139,6 +143,7 @@
                   :type="additionalProperties.type"
                   :errors="errors"
                   v-model="newValue"
+                  :reference-model="[]"
                 />
               </validation-provider>
             </template>
@@ -156,6 +161,7 @@
                   :type="additionalProperties.type"
                   :validationOb="validationOb"
                   v-model="newValue"
+                  :reference-model="''"
                 />
               </validation-provider>
             </template>
@@ -178,6 +184,7 @@
       <yaml-form
         @code::model-data-updated="updateKeyValueArray"
         v-model="modelData"
+        :reference-model="referenceModel || {}"
       />
 
       <!-- required for validation obserber and validation provider to show proper validation in yaml tab -->
@@ -192,6 +199,7 @@
           :index="index"
           :schema="schema"
           :additionalProperties="additionalProperties"
+          :reference-model="{}"
         />
       </div>
     </template>
@@ -200,6 +208,7 @@
       <json-form
         @code::model-data-updated="updateKeyValueArray"
         v-model="modelData"
+        :reference-model="referenceModel || {}"
       />
 
       <!-- required for validation obserber and validation provider to show proper validation in json tab -->
@@ -214,6 +223,7 @@
           :index="index"
           :schema="schema"
           :additionalProperties="additionalProperties"
+          :reference-model="{}"
         />
       </div>
     </template>
@@ -256,6 +266,7 @@ export default {
       newData: null,
       updatePass: 0,
       keyValueArray: null,
+      referencekeyValueArray: null,
       newKey: "",
       newValue: null,
     };
@@ -273,6 +284,14 @@ export default {
         key,
         value: this.value[key] || null,
       }));
+    },
+    initReferenceKeyValueArray() {
+      this.referencekeyValueArray = Object.keys(this.referenceModel).map(
+        (key) => ({
+          key,
+          value: this.referenceModel[key] || null,
+        })
+      );
     },
 
     updateKeyValueArray(value) {
@@ -333,6 +352,7 @@ export default {
     activeTab() {
       // re-calculate keyValueArray
       this.initKeyValueArray();
+      this.initReferenceKeyValueArray();
     },
 
     value: {
@@ -343,6 +363,8 @@ export default {
         const oldStringifiedObject = JSON.stringify(o);
         if (newStringifiedObject !== oldStringifiedObject)
           this.initKeyValueArray();
+
+        this.initReferenceKeyValueArray();
       },
     },
   },

--- a/src/components/KeyValuePairs.vue
+++ b/src/components/KeyValuePairs.vue
@@ -319,10 +319,6 @@ export default {
     },
   },
 
-  created() {
-    this.initKeyValueArray();
-  },
-
   watch: {
     keyValueArray: {
       immediate: true,
@@ -337,6 +333,17 @@ export default {
     activeTab() {
       // re-calculate keyValueArray
       this.initKeyValueArray();
+    },
+
+    value: {
+      deep: true,
+      immediate: true,
+      handler(n, o) {
+        const newStringifiedObject = JSON.stringify(n);
+        const oldStringifiedObject = JSON.stringify(o);
+        if (newStringifiedObject !== oldStringifiedObject)
+          this.initKeyValueArray();
+      },
     },
   },
 };

--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -18,6 +18,7 @@
           :schema="properties[key]"
           :errors="errors"
           v-model="modelData[key]"
+          :reference-model="referenceModel[key] || {}"
         />
       </validation-provider>
       <!-- if the property is additional property (key-value-pairs) -->
@@ -36,6 +37,7 @@
           :schema="properties[key]"
           :errors="errors"
           v-model="modelData[key]"
+          :reference-model="referenceModel[key] || {}"
         />
       </validation-provider>
       <!-- if the property is array -->
@@ -54,6 +56,7 @@
           :schema="properties[key]"
           :errors="errors"
           v-model="modelData[key]"
+          :reference-model="referenceModel[key] || []"
         />
       </validation-provider>
       <!-- if the property is simple string, number -->
@@ -72,6 +75,7 @@
           :schema="properties[key]"
           :validationOb="validationOb"
           v-model="modelData[key]"
+          :reference-model="referenceModel[key] || ''"
         />
       </validation-provider>
     </template>

--- a/src/components/ObjectFormWrapper.vue
+++ b/src/components/ObjectFormWrapper.vue
@@ -59,13 +59,14 @@
       :isRoot="isRoot"
       :isSelfFolded="isRoot ? false : isFolded"
       v-model="modelData"
+      :reference-model="referenceModel || {}"
     />
     <!-- declared in tabs component -->
     <template v-if="activeTab === 'yaml'">
-      <yaml-form v-model="modelData" />
+      <yaml-form v-model="modelData" :reference-model="referenceModel || {}" />
     </template>
     <template v-else-if="activeTab === 'json'">
-      <json-form v-model="modelData" />
+      <json-form v-model="modelData" :reference-model="referenceModel || {}" />
     </template>
   </validation-observer>
 </template>

--- a/src/components/VueOpenapiForm.vue
+++ b/src/components/VueOpenapiForm.vue
@@ -13,6 +13,7 @@
           :onlyJson="onlyJson"
           :schema="extendedSchema"
           v-model="modelData"
+          :reference-model="referenceModel || {}"
           @vof:submitted="onSubmit"
           :is-form-submitting="pending || isFormSubmitting"
         />

--- a/src/components/YamlForm.vue
+++ b/src/components/YamlForm.vue
@@ -32,6 +32,7 @@
         :key="activeTab"
         ref="monacoDiffEditor"
         class="editor-writable vh-80 is-clipped"
+        @editorDidMount="onDiffEditorMount"
         :options="editorOptions"
         :value="valueString"
         :diff-editor="true"
@@ -89,6 +90,9 @@ export default {
     ...mapGetters({
       editorTheme: "editorTheme",
     }),
+    originalValueString() {
+      return jsyaml.safeDump(this.referenceModel, { lineWidth: 2000 }); // json -> yaml
+    },
   },
 
   methods: {

--- a/src/components/YamlForm.vue
+++ b/src/components/YamlForm.vue
@@ -1,13 +1,44 @@
 <template>
   <div>
-    <monaco-editor
-      ref="monacoEditor"
-      @editorDidMount="onEditorMount"
-      v-model="valueString"
-      :options="editorOptions"
-      language="yaml"
-      class="editor-writable vh-80 is-clipped"
-    />
+    <!-- tabs start  -->
+    <div class="tabs ac-tabs is-boxed mt-10 mb-2">
+      <ul>
+        <li :class="{ 'is-active': activeTab === 'file' }">
+          <a @click.prevent="activeTab = 'file'">
+            <span>File</span>
+          </a>
+        </li>
+        <li :class="{ 'is-active': activeTab === 'preview-changes' }">
+          <a @click.prevent="activeTab = 'preview-changes'">
+            <span>Preview Changes</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div v-if="activeTab === 'file'">
+      <monaco-editor
+        ref="monacoEditor"
+        @editorDidMount="onEditorMount"
+        v-model="valueString"
+        :options="editorOptions"
+        :diff-editor="activeTab === 'preview-changes'"
+        language="yaml"
+        class="editor-writable vh-80 is-clipped"
+      />
+    </div>
+
+    <div v-else>
+      <monaco-editor
+        :key="activeTab"
+        ref="monacoDiffEditor"
+        class="editor-writable vh-80 is-clipped"
+        :options="editorOptions"
+        :value="valueString"
+        :diff-editor="true"
+        :original="originalValueString"
+        language="yaml"
+      />
+    </div>
   </div>
 </template>
 
@@ -35,6 +66,8 @@ export default {
 
   data() {
     return {
+      activeTab: "file",
+
       valueString: "",
 
       editorOptions: {
@@ -42,6 +75,12 @@ export default {
           enabled: true,
         },
         readOnly: false,
+      },
+      diffEditorOptions: {
+        minimap: {
+          enabled: true,
+        },
+        readOnly: true,
       },
     };
   },
@@ -80,6 +119,14 @@ export default {
       // set theme
       monacoEditorThemes.setTheme(
         this.$refs.monacoEditor.monaco.editor,
+        this.editorTheme
+      );
+    },
+
+    onDiffEditorMount() {
+      // set theme
+      monacoEditorThemes.setTheme(
+        this.$refs.monacoDiffEditor.monaco.editor,
         this.editorTheme
       );
     },

--- a/src/components/sub-components/ArrayInputItems.vue
+++ b/src/components/sub-components/ArrayInputItems.vue
@@ -17,6 +17,7 @@
           :type="items.type"
           :errors="errors"
           v-model="modelData[index]"
+          :reference-model="referenceModel[index] || {}"
         />
       </validation-provider>
     </template>
@@ -36,6 +37,7 @@
           }"
           :type="items.type"
           v-model="modelData[index]"
+          :reference-model="referenceModel[index] || {}"
         />
       </validation-provider>
     </template>
@@ -55,6 +57,7 @@
           :type="items.type"
           :errors="errors"
           v-model="modelData[index]"
+          :reference-model="referenceModel[index] || []"
         />
       </validation-provider>
     </template>
@@ -75,6 +78,7 @@
           :required="true"
           :validationOb="validationOb"
           v-model="modelData[index]"
+          :reference-model="referenceModel[index] || ''"
         />
       </validation-provider>
     </template>

--- a/src/components/sub-components/KeyValuePairItems.vue
+++ b/src/components/sub-components/KeyValuePairItems.vue
@@ -18,6 +18,7 @@
           :type="`string`"
           :validationOb="validationOb"
           v-model="modelData.key"
+          :reference-model="referenceModel.key || ''"
         />
       </validation-provider>
     </div>
@@ -38,6 +39,7 @@
             :type="additionalProperties.type"
             :errors="errors"
             v-model="modelData.value"
+            :reference-model="referenceModel.value || {}"
           />
         </validation-provider>
       </template>
@@ -56,6 +58,7 @@
             :type="additionalProperties.type"
             :errors="errors"
             v-model="modelData.value"
+            :reference-model="referenceModel.value || {}"
           />
         </validation-provider>
       </template>
@@ -74,6 +77,7 @@
             :type="additionalProperties.type"
             :errors="errors"
             v-model="modelData.value"
+            :reference-model="referenceModel.value || []"
           />
         </validation-provider>
       </template>
@@ -92,6 +96,7 @@
             :type="additionalProperties.type"
             :validationOb="validationOb"
             v-model="modelData.value"
+            :reference-model="referenceModel.value || ''"
           />
         </validation-provider>
       </template>

--- a/src/mixins/model.js
+++ b/src/mixins/model.js
@@ -4,6 +4,10 @@ export const model = {
       type: String,
       default: "string",
     },
+    referenceModel: {
+      type: null,
+      defult: () => ({}),
+    },
   },
 
   data() {


### PR DESCRIPTION

- Fix key value pair first item not showing initially
- Update yaml form to show preview tab and diff editor
- Pass reference model through all the necessary components, use it toshow diff in any state, pass reference model when vue openapi is called

Signed-off-by: M. A. Muhaimin Sakib <sakib@appscode.com>